### PR TITLE
Add missing rust src env for devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,15 @@
 
     devShells.x86_64-linux.default = pkgs.mkShell {
       inputsFrom = [vellum];
-      packages = with pkgs; [cargo rustc rustfmt clippy rust-analyzer];
+      packages = with pkgs; [
+        cargo
+        rustc
+        rustfmt
+        clippy
+        rust-analyzer
+      ];
+      
+      RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
     };
 
     homeModules.default = {

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,13 @@
       ];
       
       RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+      LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+        pkgs.libGL
+        pkgs.vulkan-loader
+        pkgs.wayland
+        pkgs.libxkbcommon
+      ];
     };
 
     homeModules.default = {


### PR DESCRIPTION
While rust-analyzer is present for debugging through the Rust Analyzer plugin, IDEs are unable to use the Rust package because the RUST_SRC_PATH environment variable is not set.

Another issue related to envs is  that `cargo run` fails when running the dev shell because of the missing library paths:
```
thread 'main' (99622) panicked at src/bin/render/mod.rs:225:10:
called `Result::unwrap()` on an `Err` value: CreateSurfaceError { inner: Hal(FailedToCreateSurfaceForAnyBackend({})) }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes both issues