### PR TITLE
Split package from flake + Minor improvements to package build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,7 @@
     nixpkgs,
   }: let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    vellum = pkgs.rustPlatform.buildRustPackage {
-      pname = "vellum";
-      version = (fromTOML (builtins.readFile ./Cargo.toml)).package.version;
-      src = self;
-      cargoLock.lockFile = ./Cargo.lock;
-      nativeBuildInputs = with pkgs; [pkg-config makeWrapper];
-      buildInputs = with pkgs; [wayland wayland-protocols libxkbcommon libGL vulkan-loader];
-      postInstall = ''
-        wrapProgram $out/bin/vellum \
-          --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath (with pkgs; [libGL vulkan-loader])}
-      '';
-    };
+    vellum = pkgs.callPackage ./package.nix {};
   in {
     packages.x86_64-linux = {
       inherit vellum;

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs,
   }: let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    vellum = pkgs.callPackage ./package.nix {};
+    vellum = pkgs.callPackage ./nix/package.nix {};
   in {
     packages.x86_64-linux = {
       inherit vellum;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,11 +9,21 @@
   libGL,
   vulkan-loader,
 }:
-rustPlatform.buildRustPackage rec {
+let
   pname = "vellum";
-  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../src
+    ];
+  };
 
-  src = ../.;
+  cargoToml = (builtins.fromTOML (builtins.readFile "${src}/Cargo.toml"));
+in rustPlatform.buildRustPackage {
+  inherit pname src;
+  version = cargoToml.package.version;
 
   cargoLock.lockFile = "${src}/Cargo.lock";
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,8 +8,7 @@
   libxkbcommon,
   libGL,
   vulkan-loader,
-}:
-let
+}: let
   pname = "vellum";
   src = lib.fileset.toSource {
     root = ../.;
@@ -20,28 +19,29 @@ let
     ];
   };
 
-  cargoToml = (builtins.fromTOML (builtins.readFile "${src}/Cargo.toml"));
-in rustPlatform.buildRustPackage {
-  inherit pname src;
-  version = cargoToml.package.version;
+  cargoToml = fromTOML (builtins.readFile ../Cargo.toml);
+in
+  rustPlatform.buildRustPackage {
+    inherit pname src;
+    version = cargoToml.package.version;
 
-  cargoLock.lockFile = "${src}/Cargo.lock";
+    cargoLock.lockFile = ../Cargo.lock;
 
-  nativeBuildInputs = [
-    pkg-config
-    makeWrapper
-  ];
+    nativeBuildInputs = [
+      pkg-config
+      makeWrapper
+    ];
 
-  buildInputs = [
-    wayland
-    wayland-protocols
-    libxkbcommon
-    libGL
-    vulkan-loader
-  ];
+    buildInputs = [
+      wayland
+      wayland-protocols
+      libxkbcommon
+      libGL
+      vulkan-loader
+    ];
 
-  postInstall = ''
-    wrapProgram $out/bin/vellum \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libGL vulkan-loader]}
-  '';
-}
+    postInstall = ''
+      wrapProgram $out/bin/vellum \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libGL vulkan-loader]}
+    '';
+  }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,12 +7,16 @@
   wayland-protocols,
   libxkbcommon,
   libGL,
-  vulkan-loader
-}: rustPlatform.buildRustPackage {
+  vulkan-loader,
+}:
+rustPlatform.buildRustPackage rec {
   pname = "vellum";
-  version = (fromTOML (builtins.readFile ./Cargo.toml)).package.version;
-  src = "./";
-  cargoLock.lockFile = ./Cargo.lock;
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+
+  src = ../.;
+
+  cargoLock.lockFile = "${src}/Cargo.lock";
+
   nativeBuildInputs = [
     pkg-config
     makeWrapper
@@ -28,6 +32,6 @@
 
   postInstall = ''
     wrapProgram $out/bin/vellum \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([libGL vulkan-loader])}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libGL vulkan-loader]}
   '';
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  makeWrapper,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  libGL,
+  vulkan-loader
+}: rustPlatform.buildRustPackage {
+  pname = "vellum";
+  version = (fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+  src = "./";
+  cargoLock.lockFile = ./Cargo.lock;
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libGL
+    vulkan-loader
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/vellum \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([libGL vulkan-loader])}
+  '';
+}


### PR DESCRIPTION
Improves readability of the flake by moving the vellum package declaration outside of `flake.nix`.

Other improvements:
* Reduced `src` scope to include only the files needed to compile
* Made every path relative to `src` to simplify future file structure changes