### PR TITLE
Use clap for cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +132,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -108,6 +158,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +205,12 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core_maths"
@@ -403,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +519,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jni-sys"
@@ -629,6 +737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,9 +815,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -725,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -862,7 +976,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -937,6 +1051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1078,17 @@ name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -990,7 +1121,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1093,10 +1224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vellum"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "clap",
+ "clap_derive",
  "glyphon",
  "lyon_tessellation",
  "perfect_freehand",
@@ -1151,7 +1290,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -1428,7 +1567,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1439,7 +1578,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1558,5 +1697,5 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["wayland", "annotation"]
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
 
+clap = { version = "4.6.6", features = ["derive"]}
+clap_derive = "4.6.4"
+
 wayland-client = "0.31.11"
 # layer shell
 wayland-protocols-wlr = { version = "0.3.9", features = ["client"] }

--- a/src/bin/protocol/mod.rs
+++ b/src/bin/protocol/mod.rs
@@ -15,11 +15,14 @@ pub enum Command {
     /// Clear and deactivate
     ClearAndDeactivate,
     /// Set stroke width in pixels
-    StrokeWidth { width: f32 },
+    StrokeWidth {
+        #[arg(value_parser = parse_width)]
+        width: f32,
+    },
     /// Set stroke color (hex, optional alpha)
     StrokeColor {
         #[arg(value_parser = parse_color)]
-        color: Color
+        color: Color,
     },
     /// Exit the app
     Exit,
@@ -49,14 +52,7 @@ impl Command {
             Some("clear") => Self::Clear,
             Some("clear_and_deactivate") => Self::ClearAndDeactivate,
             Some("stroke_width") => {
-                let width = parts
-                    .next()
-                    .ok_or("stroke_width requires a value")?
-                    .parse()
-                    .map_err(|_| "invalid stroke width")?;
-                if !valid_width(width) {
-                    return Err("stroke width must be positive and finite");
-                }
+                let width = parse_width(parts.next().ok_or("stroke_width requires a value")?)?;
                 Self::StrokeWidth { width }
             }
             Some("stroke_color") => Self::StrokeColor {
@@ -75,6 +71,14 @@ impl Command {
 
 pub fn valid_width(width: f32) -> bool {
     width.is_finite() && width > 0.0
+}
+
+fn parse_width(value: &str) -> Result<f32, &'static str> {
+    let width = value.parse().map_err(|_| "invalid stroke width")?;
+    if !valid_width(width) {
+        return Err("stroke width must be positive and finite");
+    }
+    Ok(width)
 }
 
 pub fn parse_color(value: &str) -> Result<Color, &'static str> {

--- a/src/bin/protocol/mod.rs
+++ b/src/bin/protocol/mod.rs
@@ -2,15 +2,26 @@ pub type Color = [f32; 4];
 
 pub const CONTROL_SOCKET: &str = "vellum.sock";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, clap::Subcommand)]
 pub enum Command {
+    /// Toggle drawing mode
     Toggle,
+    /// Undo the last stroke
     Undo,
+    /// Redo the last undone stroke
     Redo,
+    /// Clear the canvas
     Clear,
+    /// Clear and deactivate
     ClearAndDeactivate,
+    /// Set stroke width in pixels
     StrokeWidth { width: f32 },
-    StrokeColor { color: Color },
+    /// Set stroke color (hex, optional alpha)
+    StrokeColor {
+        #[arg(value_parser = parse_color)]
+        color: Color
+    },
+    /// Exit the app
     Exit,
 }
 

--- a/src/bin/vellum.rs
+++ b/src/bin/vellum.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use rustix::event::{PollFd, PollFlags, Timespec, poll};
 use wayland_client::backend::WaylandError;
+use clap::Parser;
 
 mod protocol;
 mod render;
@@ -15,72 +16,36 @@ use protocol::{CONTROL_SOCKET, Color, Command, parse_color, valid_width};
 
 const MAX_SOCKET_MESSAGE: usize = 4096;
 
-#[derive(Default)]
+#[derive(clap_derive::Parser)]
+#[command(version, about, long_about = None)]
+#[command(args_conflicts_with_subcommands = true)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Read this TOML preferences file
+    #[arg(long, conflicts_with = "no_config")]
     config: Option<std::path::PathBuf>,
+
+    /// Ignore preferences files
+    #[arg(long)]
     no_config: bool,
+
+    /// Set the initial stroke width
+    #[arg(short = 'w', long)]
     stroke_width: Option<f32>,
+
+    /// Set the initial #RRGGBB[AA] color
+    #[arg(short = 'c', long)]
     stroke_color: Option<String>,
+
+    /// Set the initial tool
+    #[arg(long)]
     default_tool: Option<String>,
+
+    /// Use vulkan or opengl
+    #[arg(short = 'b', long)]
     force_backend: Option<render::Backend>,
-}
-
-const HELP: &str = r#"Usage: vellum [OPTIONS]
-       vellum COMMAND [VALUE]
-
-Commands:
-  toggle, undo, redo, clear, clear-and-deactivate
-  stroke-width PX, stroke-color #RRGGBB[AA], exit
-
-Options:
-  --config PATH          Read this TOML preferences file
-  --no-config            Ignore preferences files
-  -w, --stroke-width PX  Set the initial stroke width
-  -c, --stroke-color HEX Set the initial #RRGGBB[AA] color
-  --default-tool TOOL    Set the initial tool
-  -b, --force-backend B  Use vulkan or opengl
-  -h, --help             Print help
-  -V, --version          Print version"#;
-
-impl Cli {
-    fn parse(arguments: impl Iterator<Item = String>) -> Result<Self, String> {
-        let mut cli = Self::default();
-        let mut args = arguments.peekable();
-        while let Some(argument) = args.next() {
-            let value = |args: &mut std::iter::Peekable<_>| {
-                args.next()
-                    .ok_or_else(|| format!("{argument} requires a value"))
-            };
-            match argument.as_str() {
-                "--config" => cli.config = Some(value(&mut args)?.into()),
-                "--no-config" => cli.no_config = true,
-                "-w" | "--stroke-width" => {
-                    cli.stroke_width =
-                        Some(value(&mut args)?.parse().map_err(|_| {
-                            "stroke width must be a positive finite number".to_string()
-                        })?)
-                }
-                "-c" | "--stroke-color" => cli.stroke_color = Some(value(&mut args)?),
-                "--default-tool" => cli.default_tool = Some(value(&mut args)?),
-                "-b" | "--force-backend" => {
-                    cli.force_backend = Some(value(&mut args)?.parse().map_err(str::to_string)?)
-                }
-                "-h" | "--help" => {
-                    println!("{HELP}");
-                    std::process::exit(0);
-                }
-                "-V" | "--version" => {
-                    println!("vellum {}", env!("CARGO_PKG_VERSION"));
-                    std::process::exit(0);
-                }
-                _ => return Err(format!("unknown option {argument:?}\n{HELP}")),
-            }
-        }
-        if cli.no_config && cli.config.is_some() {
-            return Err("--config conflicts with --no-config".into());
-        }
-        Ok(cli)
-    }
 }
 
 const DEFAULT_PALETTE: [&str; 8] = [
@@ -199,28 +164,16 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
-    let mut arguments = std::env::args().skip(1).peekable();
-    if arguments
-        .peek()
-        .is_some_and(|argument| !argument.starts_with('-'))
-    {
-        return send_command(arguments);
+    let arguments = Cli::parse();
+    if let Some(subcommand) = &arguments.command {
+        return send_command(subcommand);
     }
-    let settings = Settings::load(Cli::parse(arguments)?)?;
+    let settings = Settings::load(arguments)?;
     run_overlay(settings);
     Ok(())
 }
 
-fn send_command(arguments: impl Iterator<Item = String>) -> Result<(), String> {
-    let message = arguments
-        .map(|argument| argument.replace('-', "_"))
-        .collect::<Vec<_>>()
-        .join(" ");
-    if matches!(message.as_str(), "help") {
-        println!("{HELP}");
-        return Ok(());
-    }
-    let command = Command::deserialize(message.as_bytes()).map_err(str::to_owned)?;
+fn send_command(command: &Command) -> Result<(), String> {
     let socket_addr =
         SocketAddr::from_abstract_name(CONTROL_SOCKET).map_err(|error| error.to_string())?;
     let socket = UnixDatagram::unbound().map_err(|error| error.to_string())?;

--- a/src/bin/vellum.rs
+++ b/src/bin/vellum.rs
@@ -4,9 +4,9 @@ use std::os::unix::net::UnixDatagram;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use clap::Parser;
 use rustix::event::{PollFd, PollFlags, Timespec, poll};
 use wayland_client::backend::WaylandError;
-use clap::Parser;
 
 mod protocol;
 mod render;


### PR DESCRIPTION
Use clap as CLI parser to improve maintenance and code readability. Auto generates help commands and validates entries.

### Old CLI prompt:
```
Usage: vellum [OPTIONS]
       vellum COMMAND [VALUE]

Commands:
  toggle, undo, redo, clear, clear-and-deactivate
  stroke-width PX, stroke-color #RRGGBB[AA], exit

Options:
  --config PATH          Read this TOML preferences file
  --no-config            Ignore preferences files
  -w, --stroke-width PX  Set the initial stroke width
  -c, --stroke-color HEX Set the initial #RRGGBB[AA] color
  --default-tool TOOL    Set the initial tool
  -b, --force-backend B  Use vulkan or opengl
  -h, --help             Print help
  -V, --version          Print version
  ```
 ### new CLI prompt:
```
Live screen annotation overlay for Wayland

Usage: vellum [OPTIONS]
       vellum <COMMAND>

Commands:
  toggle                Toggle drawing mode
  undo                  Undo the last stroke
  redo                  Redo the last undone stroke
  clear                 Clear the canvas
  clear-and-deactivate  Clear and deactivate
  stroke-width          Set stroke width in pixels
  stroke-color          Set stroke color (hex, optional alpha)
  exit                  Exit the app
  help                  Print this message or the help of the given subcommand(s)

Options:
      --config <CONFIG>                Read this TOML preferences file
      --no-config                      Ignore preferences files
  -w, --stroke-width <STROKE_WIDTH>    Set the initial stroke width
  -c, --stroke-color <STROKE_COLOR>    Set the initial #RRGGBB[AA] color
      --default-tool <DEFAULT_TOOL>    Set the initial tool
  -b, --force-backend <FORCE_BACKEND>  Use vulkan or opengl
  -h, --help                           Print help
  -V, --version                        Print version
  ```