### PR TITLE
better tool radial menu colors and contrast

### DIFF
--- a/src/bin/state/draw/picker.rs
+++ b/src/bin/state/draw/picker.rs
@@ -6,8 +6,10 @@ const INNER_RADIUS: f32 = 30.0;
 const OUTER_RADIUS: f32 = 88.0;
 const WHEEL_BORDER_WIDTH: f32 = 3.0;
 const HOVER_EXTENSION: f32 = 6.0;
-const PREVIEW_BORDER_WIDTH: f32 = 2.0;
+const PREVIEW_BORDER_WIDTH: f32 = 1.0;
 const SEPARATOR_HALF_WIDTH: f32 = 2.0;
+
+const GAP_LINE_COLOR: [f32; 4] = [0.03, 0.03, 0.03, 1.0];
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum Picker {
@@ -89,7 +91,7 @@ fn push_color_preview(
     color: [f32; 4],
 ) {
     let radius = INNER_RADIUS - WHEEL_BORDER_WIDTH;
-    push_disc(buffers, center, radius, [0.8, 0.8, 0.8, 1.0]);
+    push_disc(buffers, center, radius, GAP_LINE_COLOR);
     push_disc(
         buffers,
         center,
@@ -150,7 +152,7 @@ pub(super) fn palette_geometry(
             outer + WHEEL_BORDER_WIDTH,
             start..end,
             0.0,
-            [0.04, 0.04, 0.04, 0.94],
+            GAP_LINE_COLOR,
         );
         push_wedge(
             &mut buffers,
@@ -187,7 +189,7 @@ pub(super) fn tool_palette_geometry(
             outer + WHEEL_BORDER_WIDTH,
             start..end,
             0.0,
-            [0.03, 0.03, 0.03, 0.95],
+            GAP_LINE_COLOR,
         );
         push_wedge(
             &mut buffers,

--- a/src/bin/state/draw/picker.rs
+++ b/src/bin/state/draw/picker.rs
@@ -200,9 +200,9 @@ pub(super) fn tool_palette_geometry(
             start..end,
             SEPARATOR_HALF_WIDTH,
             if is_hovered {
-                rgb_to_f32(66, 149, 232, 0.98)
+                rgb_to_f32(2, 131, 252, 0.98)
             } else if is_active {
-                rgb_to_f32(48, 91, 134, 0.95)
+                rgb_to_f32(55, 100, 138, 0.95)
             } else {
                 [0.16, 0.18, 0.22, 0.95]
             },

--- a/src/bin/state/draw/picker.rs
+++ b/src/bin/state/draw/picker.rs
@@ -1,7 +1,6 @@
 use super::scene::Point;
 use super::tool::Tool;
 use crate::render::{Geometry, Vertex};
-use crate::rgb_to_f32;
 
 const INNER_RADIUS: f32 = 30.0;
 const OUTER_RADIUS: f32 = 88.0;
@@ -11,6 +10,8 @@ const PREVIEW_BORDER_WIDTH: f32 = 1.0;
 const SEPARATOR_HALF_WIDTH: f32 = 2.0;
 
 const GAP_LINE_COLOR: [f32; 4] = [0.03, 0.03, 0.03, 1.0];
+const HOVER_COLOR: [f32; 4] = rgb_to_f32(2, 131, 252, 0.98);
+const ACTIVE_COLOR: [f32; 4] = rgb_to_f32(55, 100, 138, 0.95);
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum Picker {
@@ -200,9 +201,9 @@ pub(super) fn tool_palette_geometry(
             start..end,
             SEPARATOR_HALF_WIDTH,
             if is_hovered {
-                rgb_to_f32(2, 131, 252, 0.98)
+                HOVER_COLOR
             } else if is_active {
-                rgb_to_f32(55, 100, 138, 0.95)
+                ACTIVE_COLOR
             } else {
                 [0.16, 0.18, 0.22, 0.95]
             },
@@ -214,6 +215,10 @@ pub(super) fn tool_palette_geometry(
         push_tool_icon(&mut buffers, icon_center, tool);
     }
     Geometry::new(buffers)
+}
+
+const fn rgb_to_f32(r: u8, g: u8, b: u8, alpha: f32) -> [f32; 4] {
+    [r as f32 / 255., g as f32 / 255., b as f32 / 255., alpha]
 }
 
 fn opaque([red, green, blue, _]: [f32; 4]) -> [f32; 4] {

--- a/src/bin/state/draw/picker.rs
+++ b/src/bin/state/draw/picker.rs
@@ -1,6 +1,7 @@
 use super::scene::Point;
 use super::tool::Tool;
 use crate::render::{Geometry, Vertex};
+use crate::rgb_to_f32;
 
 const INNER_RADIUS: f32 = 30.0;
 const OUTER_RADIUS: f32 = 88.0;
@@ -199,11 +200,11 @@ pub(super) fn tool_palette_geometry(
             start..end,
             SEPARATOR_HALF_WIDTH,
             if is_hovered {
-                [0.1, 0.75, 1.0, 0.98]
+                rgb_to_f32(66, 149, 232, 0.98)
             } else if is_active {
-                [0.12, 0.38, 0.5, 0.97]
+                rgb_to_f32(48, 91, 134, 0.95)
             } else {
-                [0.16, 0.18, 0.22, 0.97]
+                [0.16, 0.18, 0.22, 0.95]
             },
         );
         let icon_center = Point::new(

--- a/src/bin/vellum.rs
+++ b/src/bin/vellum.rs
@@ -99,10 +99,6 @@ impl Settings {
     }
 }
 
-pub const fn rgb_to_f32(r: u8, g: u8, b: u8, alpha: f32) -> [f32; 4] {
-    [r as f32 / 255., g as f32 / 255., b as f32 / 255., alpha]
-}
-
 fn parse_named_color(name: &str, value: &str) -> Result<Rgb, String> {
     parse_color(value).map_err(|error| format!("invalid {name} {value:?}: {error}"))
 }

--- a/src/bin/vellum.rs
+++ b/src/bin/vellum.rs
@@ -99,6 +99,10 @@ impl Settings {
     }
 }
 
+pub const fn rgb_to_f32(r: u8, g: u8, b: u8, alpha: f32) -> [f32; 4] {
+    [r as f32 / 255., g as f32 / 255., b as f32 / 255., alpha]
+}
+
 fn parse_named_color(name: &str, value: &str) -> Result<Rgb, String> {
     parse_color(value).map_err(|error| format!("invalid {name} {value:?}: {error}"))
 }


### PR DESCRIPTION

There was a grey color ring around the color preview previously; I reset it to just black, and made that ring slightly thinner to fit in with the rest of the radial.
I understand that the reasoning for the grey outline is to make sure there is always enough contrast to be able to see the color, but black is a really good base to contrast against, and only having *that* makes the ui feel more complete / consistent — now when you switch to the color ring, the middle point doesn't change.
That's very pleasant usage-wise!

The gap line color used to be *extremely* slightly different in the tool wheel vs the colors wheel.
Difference so small that it isn't noticeable for a benefit, but noticeable in terms of something feeling “off”. So, I made them both use the same color.

I added a function `rgb_to_f32` as a way to take a normal rgb color, and convert it into the wacky three f32s format. I think this makes things easier for future contributors enough to warrant staying. Not sure where to place it though, so I blammoed it in the toppest module.

My main goal here was to fix the poor contrast of on-hover for tools. Currently the white clashes a *bit* too much with the very light cyan-ish blue. \
I decided to use the Vellum™ Colorscheme™ Blue™ as the accent color, and then an is-active color based on it. There's still enough contrast between the two, while the white on the hover stands out a bit better than on the cyan.
