### PR TITLE
triangle, rectangle, ellipse use crosshair cursor

### DIFF
--- a/src/bin/state/draw/editor/interaction.rs
+++ b/src/bin/state/draw/editor/interaction.rs
@@ -286,6 +286,11 @@ impl Editor {
             return self.tool_cursor(effective_tool);
         }
         match &self.interaction {
+            Some(Interaction::Drawing { tool, .. })
+                if [Tool::Triangle, Tool::Rectangle, Tool::Ellipse].contains(tool) =>
+            {
+                return Cursor::Shape(selection::CursorHint::Crosshair);
+            }
             Some(
                 Interaction::Freehand(_)
                 | Interaction::Drawing { .. }


### PR DESCRIPTION

especially when drawing from the center with alt, it quickly gets confusing by where you're “grabbing”, the shape you're drawing \
a clear indicator (the cursor) helps not get lost
