### PR TITLE
is-text-editing client subcommand

### DIFF
--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -30,6 +30,8 @@ pub(crate) enum Command {
     ClearAndDeactivate,
     /// Report whether drawing mode is active
     IsActive,
+    /// Report whether you are currently in a text edit
+    IsTextEditing,
     /// Stop Vellum
     Exit,
 }

--- a/src/bin/protocol/mod.rs
+++ b/src/bin/protocol/mod.rs
@@ -11,6 +11,7 @@ impl Command {
             Self::Clear => b"clear",
             Self::ClearAndDeactivate => b"clear_and_deactivate",
             Self::IsActive => b"is_active",
+            Self::IsTextEditing => b"is_text_editing",
             Self::Exit => b"exit",
         }
     }
@@ -23,6 +24,7 @@ impl Command {
             b"clear" => Ok(Self::Clear),
             b"clear_and_deactivate" => Ok(Self::ClearAndDeactivate),
             b"is_active" => Ok(Self::IsActive),
+            b"is_text_editing" => Ok(Self::IsTextEditing),
             b"exit" => Ok(Self::Exit),
             _ => Err("invalid command"),
         }

--- a/src/bin/state/mod.rs
+++ b/src/bin/state/mod.rs
@@ -255,6 +255,10 @@ impl State {
         self.active
     }
 
+    pub fn is_text_editing(&self) -> bool {
+        self.draw.is_editing_text()
+    }
+
     pub fn set_input_active(&mut self, active: bool) {
         if active == self.active {
             return;

--- a/src/bin/vellum.rs
+++ b/src/bin/vellum.rs
@@ -34,17 +34,20 @@ fn main() -> ExitCode {
 fn run() -> Result<ExitCode, String> {
     let arguments = Cli::parse();
     if let Some(subcommand) = &arguments.command {
-        if matches!(subcommand, Command::IsActive) {
-            let active = query_active()?;
-            println!("{active}");
-            return Ok(if active {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::from(1)
-            });
-        }
-        send_command(subcommand)?;
-        return Ok(ExitCode::SUCCESS);
+        let truthy_value = match subcommand {
+            Command::IsActive => query_active()?,
+            Command::IsTextEditing => query_text_editing()?,
+            _ => {
+                send_command(subcommand)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+        };
+        println!("{truthy_value}");
+        return Ok(if truthy_value {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(1)
+        });
     }
     let settings = Settings::load(arguments)?;
     run_overlay(settings);
@@ -65,6 +68,14 @@ fn send_command(command: &Command) -> Result<(), String> {
 }
 
 fn query_active() -> Result<bool, String> {
+    query(Command::IsActive.serialize())
+}
+
+fn query_text_editing() -> Result<bool, String> {
+    query(Command::IsTextEditing.serialize())
+}
+
+fn query(request: &[u8]) -> Result<bool, String> {
     let socket_addr =
         SocketAddr::from_abstract_name(CONTROL_SOCKET).map_err(|error| error.to_string())?;
     let reply_name = format!(
@@ -87,7 +98,7 @@ fn query_active() -> Result<bool, String> {
     socket
         .set_read_timeout(Some(Duration::from_secs(1)))
         .map_err(|error| format!("could not configure control socket: {error}"))?;
-    if let Err(error) = socket.send(Command::IsActive.serialize()) {
+    if let Err(error) = socket.send(request) {
         if error.kind() == std::io::ErrorKind::ConnectionRefused {
             return Ok(false);
         }
@@ -223,6 +234,16 @@ fn run_overlay(settings: Settings) {
                     }
                     Command::IsActive => {
                         let response: &[u8] = if state.is_active() { b"true" } else { b"false" };
+                        if let Err(error) = socket.send_to_addr(response, &sender) {
+                            eprintln!("vellum: could not send status: {error}");
+                        }
+                    }
+                    Command::IsTextEditing => {
+                        let response: &[u8] = if state.is_text_editing() {
+                            b"true"
+                        } else {
+                            b"false"
+                        };
                         if let Err(error) = socket.send_to_addr(response, &sender) {
                             eprintln!("vellum: could not send status: {error}");
                         }


### PR DESCRIPTION

similar to the `is-active` subcommand, but reports whether you are currently editing text

overall, vellum is fairly keyboard free. you can do almost anything from the mouse entirely. \
and it's why I put vellum manipulation on top of my [mouse mode](https://axlefublr.github.io/mouse-mode) \
however I often run into the situation where I do remember to quit mouse mode, but forget to quit vellum. if I'm exiting mouse mode, I'm also necessarily mentally exiting vellum. \
however that is not safe in one single case¹ — text editing. if you created a text annotation, if you deactivate vellum you will also deactivate editing that textbox (as expected).

with this patch, I can safely express “whenever I exit mouse mode, I also exit vellum. UNLESS I'm editing text, in which case only leave mouse mode, but don't exit vellum”. there isn't a consistent way to track this otherwise.
