### PR TITLE
more text editing hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ Mod+A { spawn "vellum" "toggle"; }
 | `Ctrl` + scroll | Change opacity |
 | `Shift` + scroll | Change roundness |
 
+### Text editing
+
+|Input|Action|
+|-|-|
+|<kbd>Left</kbd> / <kbd>Ctrl+B</kbd>|Move cursor to the left|
+|<kbd>Right</kbd> / <kbd>Ctrl+F</kbd>|Move cursor to the right|
+|<kbd>Ctrl+Left</kbd> / <kbd>Alt+B</kbd>|Move cursor to the previous word|
+|<kbd>Ctrl+Right</kbd> / <kbd>Alt+F</kbd>|Move cursor to the next word|
+|<kbd>Home</kbd> / <kbd>Ctrl+A</kbd>|Move cursor to start|
+|<kbd>End</kbd> / <kbd>Ctrl+E</kbd>|Move cursor to end|
+|<kbd>Backspace</kbd> / <kbd>Ctrl+H</kbd>|Delete previous character|
+|<kbd>Ctrl+Backspace</kbd> / <kbd>Ctrl+W</kbd>|Delete previous word|
+|<kbd>Delete</kbd> / <kbd>Ctrl+D</kbd>|Delete next character|
+|<kbd>Ctrl+Delete</kbd> / <kbd>Alt+D</kbd>|Delete next word|
+|<kbd>Ctrl+U</kbd>|Delete to start|
+|<kbd>Ctrl+K</kbd>|Delete to end|
+
 Drag selection handles to reshape supported elements.
 
 Run `vellum --help` or `man vellum` for startup options and commands.

--- a/src/bin/state/draw/editor/mod.rs
+++ b/src/bin/state/draw/editor/mod.rs
@@ -22,6 +22,7 @@ pub(crate) enum Action {
     ToggleEraser,
     ToggleFill,
     Delete,
+    DeleteWord,
     Clear,
     Cancel,
     CommitText,
@@ -221,6 +222,11 @@ impl Editor {
                     effect.damage = Damage::from_preview(edit.delete());
                 } else {
                     effect.damage = self.delete_selection();
+                }
+            }
+            Action::DeleteWord => {
+                if let Some(edit) = self.text_edit_mut() {
+                    effect.damage = Damage::from_preview(edit.delete_word());
                 }
             }
             Action::Clear => effect.damage = self.clear(),

--- a/src/bin/state/draw/editor/mod.rs
+++ b/src/bin/state/draw/editor/mod.rs
@@ -24,6 +24,7 @@ pub(crate) enum Action {
     Delete,
     DeleteWord,
     DeleteToStart,
+    DeleteToEnd,
     Clear,
     Cancel,
     CommitText,
@@ -233,6 +234,11 @@ impl Editor {
             Action::DeleteToStart => {
                 if let Some(edit) = self.text_edit_mut() {
                     effect.damage = Damage::from_preview(edit.delete_to_start());
+                }
+            }
+            Action::DeleteToEnd => {
+                if let Some(edit) = self.text_edit_mut() {
+                    effect.damage = Damage::from_preview(edit.delete_to_end());
                 }
             }
             Action::Clear => effect.damage = self.clear(),

--- a/src/bin/state/draw/editor/mod.rs
+++ b/src/bin/state/draw/editor/mod.rs
@@ -23,6 +23,7 @@ pub(crate) enum Action {
     ToggleFill,
     Delete,
     DeleteWord,
+    DeleteToStart,
     Clear,
     Cancel,
     CommitText,
@@ -227,6 +228,11 @@ impl Editor {
             Action::DeleteWord => {
                 if let Some(edit) = self.text_edit_mut() {
                     effect.damage = Damage::from_preview(edit.delete_word());
+                }
+            }
+            Action::DeleteToStart => {
+                if let Some(edit) = self.text_edit_mut() {
+                    effect.damage = Damage::from_preview(edit.delete_to_start());
                 }
             }
             Action::Clear => effect.damage = self.clear(),

--- a/src/bin/state/draw/editor/mod.rs
+++ b/src/bin/state/draw/editor/mod.rs
@@ -260,7 +260,7 @@ impl Editor {
                     effect.damage = Damage::Preview;
                 }
             }
-            _ => {}
+            Action::Redo | Action::Undo => (),
         }
         effect.damage = effect.damage.max(Damage::from_preview(closed_picker));
         effect

--- a/src/bin/state/draw/text_edit.rs
+++ b/src/bin/state/draw/text_edit.rs
@@ -64,6 +64,14 @@ impl TextEdit {
         true
     }
 
+    pub(super) fn delete_to_start(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= self.content.drain(..self.cursor).count();
+        true
+    }
+
     pub(super) fn move_cursor(&mut self, movement: CursorMove) -> bool {
         let cursor = match movement {
             CursorMove::Left => previous_boundary(&self.content, self.cursor),

--- a/src/bin/state/draw/text_edit.rs
+++ b/src/bin/state/draw/text_edit.rs
@@ -55,6 +55,15 @@ impl TextEdit {
         true
     }
 
+    pub(super) fn delete_word(&mut self) -> bool {
+        if self.cursor == self.content.len() {
+            return false;
+        }
+        let next = next_word_boundary(&self.content, self.cursor);
+        self.content.drain(self.cursor..next);
+        true
+    }
+
     pub(super) fn move_cursor(&mut self, movement: CursorMove) -> bool {
         let cursor = match movement {
             CursorMove::Left => previous_boundary(&self.content, self.cursor),

--- a/src/bin/state/draw/text_edit.rs
+++ b/src/bin/state/draw/text_edit.rs
@@ -72,6 +72,14 @@ impl TextEdit {
         true
     }
 
+    pub(super) fn delete_to_end(&mut self) -> bool {
+        if self.cursor == self.content.len() {
+            return false;
+        }
+        self.content.drain(self.cursor..);
+        true
+    }
+
     pub(super) fn move_cursor(&mut self, movement: CursorMove) -> bool {
         let cursor = match movement {
             CursorMove::Left => previous_boundary(&self.content, self.cursor),

--- a/src/bin/state/input/keyboard.rs
+++ b/src/bin/state/input/keyboard.rs
@@ -38,6 +38,7 @@ fn resolve_keybinding(chord: &KeyChord, editing_text: bool) -> Option<Action> {
     if editing_text {
         return match &chord.key {
             Escape => Some(Action::Cancel),
+            Delete if chord.modifiers.ctrl => Some(Action::DeleteWord),
             Delete => Some(Action::Delete),
             Backspace if chord.modifiers.ctrl => Some(Action::BackspaceWord),
             Backspace => Some(Action::Backspace),

--- a/src/bin/state/input/keyboard.rs
+++ b/src/bin/state/input/keyboard.rs
@@ -13,6 +13,7 @@ const SELECT_ALL_KEY: &str = "a";
 const UNDO_KEY: &str = "z";
 const REDO_KEY: &str = "y";
 const TOGGLE_FILL_KEY: &str = "f";
+const DELETE_TO_START_KEY: &str = "u";
 
 enum LogicalKey {
     Character(String),
@@ -49,7 +50,14 @@ fn resolve_keybinding(chord: &KeyChord, editing_text: bool) -> Option<Action> {
             ArrowRight => Some(Action::MoveCursor(CursorMove::Right)),
             Home => Some(Action::MoveCursor(CursorMove::Home)),
             End => Some(Action::MoveCursor(CursorMove::End)),
-            Character(text) if !chord.modifiers.ctrl && !text.chars().any(char::is_control) => {
+            Character(text) if chord.modifiers.ctrl => {
+                if text.eq_ignore_ascii_case(DELETE_TO_START_KEY) {
+                    Some(Action::DeleteToStart)
+                } else {
+                    None
+                }
+            }
+            Character(text) if !text.chars().any(char::is_control) => {
                 Some(Action::InsertText(text.clone()))
             }
             _ => None,

--- a/src/bin/state/input/keyboard.rs
+++ b/src/bin/state/input/keyboard.rs
@@ -14,6 +14,7 @@ const UNDO_KEY: &str = "z";
 const REDO_KEY: &str = "y";
 const TOGGLE_FILL_KEY: &str = "f";
 const DELETE_TO_START_KEY: &str = "u";
+const DELETE_TO_END_KEY: &str = "k";
 
 enum LogicalKey {
     Character(String),
@@ -53,6 +54,8 @@ fn resolve_keybinding(chord: &KeyChord, editing_text: bool) -> Option<Action> {
             Character(text) if chord.modifiers.ctrl => {
                 if text.eq_ignore_ascii_case(DELETE_TO_START_KEY) {
                     Some(Action::DeleteToStart)
+                } else if text.eq_ignore_ascii_case(DELETE_TO_END_KEY) {
+                    Some(Action::DeleteToEnd)
                 } else {
                     None
                 }

--- a/src/bin/state/input/keyboard.rs
+++ b/src/bin/state/input/keyboard.rs
@@ -15,6 +15,13 @@ const REDO_KEY: &str = "y";
 const TOGGLE_FILL_KEY: &str = "f";
 const DELETE_TO_START_KEY: &str = "u";
 const DELETE_TO_END_KEY: &str = "k";
+const EMACS_BACKSPACE_KEY: &str = "h";
+const EMACS_BACKSPACE_WORD_KEY: &str = "w";
+const EMACS_DELETE_KEY: &str = "d";
+const EMACS_RIGHT_KEY: &str = "f";
+const EMACS_LEFT_KEY: &str = "b";
+const EMACS_START_KEY: &str = "a";
+const EMACS_END_KEY: &str = "e";
 
 enum LogicalKey {
     Character(String),
@@ -52,10 +59,35 @@ fn resolve_keybinding(chord: &KeyChord, editing_text: bool) -> Option<Action> {
             Home => Some(Action::MoveCursor(CursorMove::Home)),
             End => Some(Action::MoveCursor(CursorMove::End)),
             Character(text) if chord.modifiers.ctrl => {
-                if text.eq_ignore_ascii_case(DELETE_TO_START_KEY) {
+                if text.eq_ignore_ascii_case(EMACS_DELETE_KEY) {
+                    Some(Action::Delete)
+                } else if text.eq_ignore_ascii_case(EMACS_BACKSPACE_KEY) {
+                    Some(Action::Backspace)
+                } else if text.eq_ignore_ascii_case(EMACS_BACKSPACE_WORD_KEY) {
+                    Some(Action::BackspaceWord)
+                } else if text.eq_ignore_ascii_case(EMACS_LEFT_KEY) {
+                    Some(Action::MoveCursor(CursorMove::Left))
+                } else if text.eq_ignore_ascii_case(EMACS_RIGHT_KEY) {
+                    Some(Action::MoveCursor(CursorMove::Right))
+                } else if text.eq_ignore_ascii_case(EMACS_START_KEY) {
+                    Some(Action::MoveCursor(CursorMove::Home))
+                } else if text.eq_ignore_ascii_case(EMACS_END_KEY) {
+                    Some(Action::MoveCursor(CursorMove::End))
+                } else if text.eq_ignore_ascii_case(DELETE_TO_START_KEY) {
                     Some(Action::DeleteToStart)
                 } else if text.eq_ignore_ascii_case(DELETE_TO_END_KEY) {
                     Some(Action::DeleteToEnd)
+                } else {
+                    None
+                }
+            }
+            Character(text) if chord.modifiers.alt => {
+                if text.eq_ignore_ascii_case(EMACS_DELETE_KEY) {
+                    Some(Action::DeleteWord)
+                } else if text.eq_ignore_ascii_case(EMACS_LEFT_KEY) {
+                    Some(Action::MoveCursor(CursorMove::WordLeft))
+                } else if text.eq_ignore_ascii_case(EMACS_RIGHT_KEY) {
+                    Some(Action::MoveCursor(CursorMove::WordRight))
                 } else {
                     None
                 }


### PR DESCRIPTION

Added missing <kbd>Ctrl+Delete</kbd> hotkey, plus a bunch of emacs hotkeys people might expect / appreciate having.

|hotkey|action|
|-|-|
|<kbd>Ctrl+Delete</kbd>|Delete next word|
|<kbd>Ctrl+U</kbd>|Delete to start|
|<kbd>Ctrl+K</kbd>|Delete to end|
|<kbd>Ctrl+D</kbd>|Delete next character|
|<kbd>Alt+D</kbd>|Delete next word|
|<kbd>Ctrl+H</kbd>|Delete previous character|
|<kbd>Ctrl+W</kbd>|Delete previous word|
|<kbd>Ctrl+F</kbd>|Move cursor to the right|
|<kbd>Ctrl+B</kbd>|Move cursor to the left|
|<kbd>Alt+F</kbd>|Move cursor to the next word|
|<kbd>Alt+B</kbd>|Move cursor to the previous word|
|<kbd>Ctrl+A</kbd>|Move cursor to start|
|<kbd>Ctrl+E</kbd>|Move cursor to end|
