### PR TITLE
palette: improve colors, match black and white to other colors

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -16,13 +16,13 @@ size_range = {
 
 palette = [
   "#E84046",
-  "#EC8948",
-  "#EED049",
-  "#3ED73C",
-  "#0283FC",
-  "#7C57EB",
-  "#FFFFFF",
-  "#000000",
+  "#EF8F4F",
+  "#EED14D",
+  "#4DD54F",
+  "#0483FA",
+  "#7C58EA",
+  "#EBEBEB",
+  "#141414",
 ]
 
 [tools.pen]

--- a/src/bin/config/mod.rs
+++ b/src/bin/config/mod.rs
@@ -11,7 +11,7 @@ const DEFAULT_TEXT_MIN_SIZE: f32 = 8.0;
 const DEFAULT_TEXT_MAX_SIZE: f32 = 500.0;
 const DEFAULT_TEXT_STEP: f32 = 0.5;
 const DEFAULT_PALETTE: [&str; 8] = [
-    "#E84046", "#EC8948", "#EED049", "#3ED73C", "#0283FC", "#7C57EB", "#FFFFFF", "#000000",
+    "#E84046", "#EF8F4F", "#EED14D", "#4DD54F", "#0483FA", "#7C58EA", "#EBEBEB", "#141414",
 ];
 
 #[derive(Debug, Default, serde::Deserialize)]

--- a/src/bin/render/text.rs
+++ b/src/bin/render/text.rs
@@ -9,8 +9,8 @@ use super::{srgb_to_linear, vello_color};
 
 const DARK_TEXT_EMBOLDENING: f64 = 0.2;
 const LINE_HEIGHT_SCALE: f32 = 1.25;
-const BLACK_BACKGROUND_COLOR: f32 = 0.07843137255;
-const WHITE_BACKGROUND_COLOR: f32 = 0.9215686275;
+const BLACK_BACKGROUND_COLOR: f32 = 0.078_431_372_55;
+const WHITE_BACKGROUND_COLOR: f32 = 0.921_568_627_50;
 
 pub fn text_line_height(font_size: f32) -> f32 {
     font_size * LINE_HEIGHT_SCALE

--- a/src/bin/render/text.rs
+++ b/src/bin/render/text.rs
@@ -9,6 +9,8 @@ use super::{srgb_to_linear, vello_color};
 
 const DARK_TEXT_EMBOLDENING: f64 = 0.2;
 const LINE_HEIGHT_SCALE: f32 = 1.25;
+const BLACK_BACKGROUND_COLOR: f32 = 0.07843137255;
+const WHITE_BACKGROUND_COLOR: f32 = 0.9215686275;
 
 pub fn text_line_height(font_size: f32) -> f32 {
     font_size * LINE_HEIGHT_SCALE
@@ -57,9 +59,19 @@ fn background_color([red, green, blue, alpha]: [f32; 4]) -> [f32; 4] {
     let contrast_with_black = (luminance + 0.05) / 0.05;
     let contrast_with_white = 1.05 / (luminance + 0.05);
     if contrast_with_black >= contrast_with_white {
-        [0.0, 0.0, 0.0, alpha]
+        [
+            BLACK_BACKGROUND_COLOR,
+            BLACK_BACKGROUND_COLOR,
+            BLACK_BACKGROUND_COLOR,
+            alpha,
+        ]
     } else {
-        [1.0, 1.0, 1.0, alpha]
+        [
+            WHITE_BACKGROUND_COLOR,
+            WHITE_BACKGROUND_COLOR,
+            WHITE_BACKGROUND_COLOR,
+            alpha,
+        ]
     }
 }
 

--- a/src/bin/render/text.rs
+++ b/src/bin/render/text.rs
@@ -9,8 +9,8 @@ use super::{srgb_to_linear, vello_color};
 
 const DARK_TEXT_EMBOLDENING: f64 = 0.2;
 const LINE_HEIGHT_SCALE: f32 = 1.25;
-const BLACK_BACKGROUND_COLOR: f32 = 0.078_431_372_55;
-const WHITE_BACKGROUND_COLOR: f32 = 0.921_568_627_50;
+const BLACK_BACKGROUND_COLOR: f32 = 0.078_431_375;
+const WHITE_BACKGROUND_COLOR: f32 = 0.921_568_63;
 
 pub fn text_line_height(font_size: f32) -> f32 {
     font_size * LINE_HEIGHT_SCALE

--- a/src/bin/render/text.rs
+++ b/src/bin/render/text.rs
@@ -9,8 +9,8 @@ use super::{srgb_to_linear, vello_color};
 
 const DARK_TEXT_EMBOLDENING: f64 = 0.2;
 const LINE_HEIGHT_SCALE: f32 = 1.25;
-const BLACK_BACKGROUND_COLOR: f32 = 0.078_431_375;
-const WHITE_BACKGROUND_COLOR: f32 = 0.921_568_63;
+const BLACK_BACKGROUND_COLOR: f32 = 20.0 / 255.0;
+const WHITE_BACKGROUND_COLOR: f32 = 235.0 / 255.0;
 
 pub fn text_line_height(font_size: f32) -> f32 {
     font_size * LINE_HEIGHT_SCALE
@@ -56,23 +56,16 @@ fn background_color([red, green, blue, alpha]: [f32; 4]) -> [f32; 4] {
     let luminance = 0.2126 * srgb_to_linear(red)
         + 0.7152 * srgb_to_linear(green)
         + 0.0722 * srgb_to_linear(blue);
-    let contrast_with_black = (luminance + 0.05) / 0.05;
-    let contrast_with_white = 1.05 / (luminance + 0.05);
-    if contrast_with_black >= contrast_with_white {
-        [
-            BLACK_BACKGROUND_COLOR,
-            BLACK_BACKGROUND_COLOR,
-            BLACK_BACKGROUND_COLOR,
-            alpha,
-        ]
+    let contrast = |background| {
+        let background_luminance = srgb_to_linear(background);
+        (luminance.max(background_luminance) + 0.05) / (luminance.min(background_luminance) + 0.05)
+    };
+    let background = if contrast(BLACK_BACKGROUND_COLOR) >= contrast(WHITE_BACKGROUND_COLOR) {
+        BLACK_BACKGROUND_COLOR
     } else {
-        [
-            WHITE_BACKGROUND_COLOR,
-            WHITE_BACKGROUND_COLOR,
-            WHITE_BACKGROUND_COLOR,
-            alpha,
-        ]
-    }
+        WHITE_BACKGROUND_COLOR
+    };
+    [background, background, background, alpha]
 }
 
 pub struct TextSpec<'a> {

--- a/src/bin/state/draw/picker.rs
+++ b/src/bin/state/draw/picker.rs
@@ -17,8 +17,8 @@ const PREVIEW_BORDER_WIDTH: f32 = 1.0;
 const SEPARATOR_HALF_WIDTH: f32 = 2.0;
 
 const GAP_LINE_COLOR: [f32; 4] = [0.03, 0.03, 0.03, 1.0];
-const HOVER_COLOR: [f32; 4] = rgb_to_f32(2, 131, 252, 0.98);
-const ACTIVE_COLOR: [f32; 4] = rgb_to_f32(55, 100, 138, 0.95);
+const HOVER_COLOR: [f32; 4] = rgb_to_f32(4, 131, 250, 0.98);
+const ACTIVE_COLOR: [f32; 4] = rgb_to_f32(57, 100, 136, 0.95);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Choice {


### PR DESCRIPTION

When initially designing the vellum palette, I left black and white “raw”, thinking that them being “absolute” was a helpful promise to make to the user. But after looking at the colors enough, especially in the context of text backgrounds, I no longer think so.

Modified every color except red, doing the most work on black, white, green and orange. \
You heard me: I did change blue. But not to worry! Changed only slightly. \
Blue (usually text) on black background was really jarring and the genuinely 2% saturation difference made it look *way* better. \
I updated the blue used in the radial ui; there may be other places where blue is used? But I'm not aware of any, so I might've missed some other blue places. Grepped for the color and didn't come across anywhere else.

Overall, the theme of the redesign is to match the colors together better: some of them (green in particular) stood out jarringly. Now they are more theme-ful 😌

Updated the default text background contrastors to use the new black and white. I want the float representations to be as close to the hex representations as possible, so that introduces a scary ass magic number; made a const variable for them

Default config updated to match reality
